### PR TITLE
Add routes provided by the server

### DIFF
--- a/login.py
+++ b/login.py
@@ -8,6 +8,7 @@ import argparse
 import logging
 import requests
 import sys
+import re
 
 log = logging.getLogger("schmextender")
 
@@ -82,12 +83,17 @@ class Login(object):
 
         s.close()
 
+        # Parse the response
+        res = {}
+        for x in re.findall('^([a-zA-Z.]+) = ?"?([^"\n;]*)"?;?$', r.text, re.M):
+            res.setdefault(x[0], []).append(x[1])
+
         # Finished!
         self.log.info("Got authorization code")
         self.log.debug("Now set up the tunnel using this authorization code: %s",
                        r.cookies["swap"])
 
-        return r.cookies["swap"]
+        return (r.cookies["swap"], res)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
@@ -122,4 +128,4 @@ if __name__ == "__main__":
     if auth is None:
         sys.exit(-1)
 
-    print("Authorization code: %s" % auth)
+    print("Authorization code: %s" % auth[0])

--- a/schmextender.py
+++ b/schmextender.py
@@ -11,8 +11,32 @@ import logging
 from login import Login
 from tunnel import Tunnel
 import sys
+import subprocess
+import _thread
+import time
 
 log = logging.getLogger("schmextender")
+
+# Prepare the interface by adding routes
+# This is something that is usually done in the ppp ip-up script
+def prepare_interface(name, data):
+    # Try for a few seconds
+    up = False
+    for _ in range(6):
+        try:
+            if subprocess.check_output(["/usr/sbin/ip", "link", "show", "up", "dev", name], stderr=sys.stderr):
+                up = True
+                break
+        except CalledProcessError:
+            pass
+        time.sleep(0.5)
+
+    if not up:
+        return
+
+    for r in data.setdefault("Route", []):
+        log.info("Adding route to %s", r)
+        subprocess.call(["/usr/sbin/ip", "route", "add", r, "dev", name], stdout=sys.stderr, stderr=sys.stderr)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
@@ -46,6 +70,9 @@ if __name__ == "__main__":
     auth = login.run()
     if auth is None:
         sys.exit(-1)
+
+    log.warning("Assuming ppp0 interface");
+    _thread.start_new_thread(prepare_interface, ("ppp0", auth[1]))
 
     tunnel = Tunnel(hostname, port)
     tunnel.connect(auth[0], noverify=args.noverify)

--- a/schmextender.py
+++ b/schmextender.py
@@ -48,5 +48,5 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     tunnel = Tunnel(hostname, port)
-    tunnel.connect(auth, noverify=args.noverify)
+    tunnel.connect(auth[0], noverify=args.noverify)
     tunnel.run()


### PR DESCRIPTION
This will setup the routes provided by the server. It's currently limited to assuming ppp0, but there are ways to detect that.

- the IP address of the ppp interface is known through the same mechanism as the routes.
- the parent pid is known, i.e. os.getppid(). Look in /var/run/ppp?.pid for a file matching this.
- parse /var/run/ppp/pppd2.tdb and match with either pid or ip address.