### PR TITLE
Handle BlockingIOError when flushing stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ sudo pppd nodetach file ppp_conf pty "./schmextender.py --username USERNAME --pa
 
 
 ## Limitation
-- Issue with blocking write, sometimes it casues an exception.
 - No keep alive, if the client is to slient, the connection will be closed.
 - Doesn't install defualt routes if asked by the server
 - Doesn't install DNS related information, such as resolvers and search domains.

--- a/tunnel.py
+++ b/tunnel.py
@@ -47,7 +47,6 @@ class Tunnel(object):
             data = data[lenfield:]
         if self.more_remote > 0:
             self.log.debug("Waiting for %d B" % self.more_remote)
-        sys.stdout.flush()
 
     def connect(self, auth, noverify=False):
         context = ssl.create_default_context()
@@ -86,14 +85,18 @@ class Tunnel(object):
                 local = sys.stdin.buffer.read(1024)
 
             try:
+                # This should be a no-op in most cases
+                sys.stdout.flush()
                 remote = self.conn.recv(4096)
                 while len(remote) > 0:
                     self.gotRemoteData(remote)
+                    sys.stdout.flush()
                     remote = self.conn.recv(4096)
             except ssl.SSLWantReadError:
                 self.log.debug("Want read")
+            except BlockingIOError:
+                self.log.debug("Would block")
 
-        
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     


### PR DESCRIPTION
The sys.stdout.flush() would sometime raise an exception that it would
block. Move flushing outside the function and flush at the beginning so
that any pending data is written regardless.

There is probably some corner cases if this happens at the moment when
traffic stops. The select call would probably hang and some data might
get stuck in the stdout buffer.

Anyway, this is an improvement regardless.